### PR TITLE
[DLAB-9932] Allows Guzzle ^7.0 and Monolog ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.1",
+        "guzzlehttp/guzzle": "^6.1 || ^7.0",
         "monolog/monolog": "~1.22 || ~2.0"
     },
     "require-dev": {
-	"phpunit/phpunit": "^5.7"
+	    "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^6.1 || ^7.0",
-        "monolog/monolog": "~1.22 || ~2.0"
+        "monolog/monolog": "~1.22 || ~2.0 || ~3.0"
     },
     "require-dev": {
 	    "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
[Ticket DLAB-9932](https://chargebacks911.atlassian.net/browse/DLAB-9932)

Related PRs:

- this PR is a dependency of:     
  - 1. `drm-scheme` https://github.com/eresponseservices/drm-scheme/pull/338
  - 2. `mastercard-mastercom-php` https://github.com/eresponseservices/mastercard-mastercom-php/pull/4
  
 ### Description

Allows new versions of guzzle and monolog. That way I can upgrade it on drm-scheme.

The library tests with monolog ^2 were already broken due to a method that only exists on v1:

https://github.com/eresponseservices/mastercard-sdk-core-php/blob/4eb01c23fcdc73d33a3868e8261ab93f1c54563a/Test/MasterCard/Api/BaseTest.php#L58

So I haven't taken attention to that.